### PR TITLE
Update ChatMessage.test.js

### DIFF
--- a/frontend/src/__tests__/ChatMessage.test.js
+++ b/frontend/src/__tests__/ChatMessage.test.js
@@ -25,7 +25,7 @@ describe('ChatMessage', () => {
     expect(screen.getByText('TritonHealthBot')).toBeInTheDocument();
     expect(screen.getByText('Parsed markdown: Bot message')).toBeInTheDocument();
     sources.forEach((src) => {
-      expect(screen.getByText(`${src.metadata.source}, page ${src.metadata.page}`, { selector: 'a' })).toBeInTheDocument();
+      expect(screen.getByText(`${src.metadata.source}`, { selector: 'a' })).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
Update ChatMessage test because we removed the page number from the source citations in the ChatMessage component.